### PR TITLE
add grid math operations

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -252,8 +252,9 @@ impl<T: Clone> Grid<T> {
     /// multiplies each value in the grid with each value at the same
     /// coordinate in the other grid
     /// and returns a new grid, leaving the parameters untouched
+    ///
     /// panics if dimensions don't match
-    pub fn mul<R, O>(&mut self, other: &Grid<R>) -> Grid<O>
+    pub fn mul<R, O>(&self, other: &Grid<R>) -> Grid<O>
     where
         T: Mul<R, Output = O>,
         R: Clone,
@@ -273,6 +274,7 @@ impl<T: Clone> Grid<T> {
     /// multiplies each value in the grid with each value at the same
     /// coordinate in the other grid
     /// modifies the grid in place
+    ///
     /// panics if dimensions don't match
     fn mul_inplace<R>(&mut self, other: &Grid<R>) -> &mut Self
     where
@@ -287,10 +289,8 @@ impl<T: Clone> Grid<T> {
     }
 
     /// multiplies each value in the grid with the scalar
-    /// coordinate in the other grid
-    /// modifies the grid in place
-    /// panics if dimensions don't match
-    fn mul_scalar<R, O>(&mut self, scalar: R) -> Grid<O>
+    /// and returns a new grid, leaving the old one untouched
+    fn mul_scalar<R, O>(&self, scalar: R) -> Grid<O>
     where
         T: Mul<R, Output = O>,
         R: Clone,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -236,6 +236,7 @@ impl<T: Clone> Grid<T> {
     }
 
     /// asserts that both grids have the same dimensions
+    /// panics if they don't
     pub fn ensure_dimensions_match<R>(&self, other: &Grid<R>) {
         assert_eq!(
             self.width, other.width,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -276,7 +276,7 @@ impl<T: Clone> Grid<T> {
     /// modifies the grid in place
     ///
     /// panics if dimensions don't match
-    fn mul_inplace<R>(&mut self, other: &Grid<R>) -> &mut Self
+    pub fn mul_inplace<R>(&mut self, other: &Grid<R>) -> &mut Self
     where
         T: Mul<R, Output = T>,
         R: Clone,
@@ -290,11 +290,12 @@ impl<T: Clone> Grid<T> {
 
     /// multiplies each value in the grid with the scalar
     /// and returns a new grid, leaving the old one untouched
-    fn mul_scalar<R, O>(&self, scalar: R) -> Grid<O>
+    pub fn mul_scalar<R, O>(&self, scalar: impl AsRef<R>) -> Grid<O>
     where
         T: Mul<R, Output = O>,
         R: Clone,
     {
+        let scalar = scalar.as_ref();
         let mut data: Vec<O> = Vec::with_capacity(self.data.len());
         for lhs in self.data.iter() {
             data.push(lhs.clone().mul(scalar.clone()));
@@ -303,6 +304,24 @@ impl<T: Clone> Grid<T> {
             data,
             width: self.width,
             height: self.height,
+        }
+    }
+
+    /// clamps all values in the grid, so that
+    /// `min <= value <= max`
+    pub fn clamp_values<Ref>(&mut self, min: Ref, max: Ref)
+    where
+        T: PartialOrd<T>,
+        Ref: AsRef<T>,
+    {
+        let min = min.as_ref();
+        let max = max.as_ref();
+        for value in self.data.iter_mut() {
+            if (*value).lt(min) {
+                *value = min.clone();
+            } else if (*value).gt(max) {
+                *value = max.clone();
+            }
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 use glam::IVec2;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
-use std::ops::{Index, IndexMut, Mul};
+use std::ops::{Add, Index, IndexMut, Mul};
 
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -285,6 +285,45 @@ impl<T: Clone> Grid<T> {
         self.ensure_dimensions_match(other);
         for (lhs, rhs) in self.data.iter_mut().zip(other.data.iter()) {
             *lhs = lhs.clone().mul(rhs.clone());
+        }
+        self
+    }
+
+    /// adds each value in the grid with each value at the same
+    /// coordinate in the other grid
+    /// and returns a new grid, leaving the parameters untouched
+    ///
+    /// panics if dimensions don't match
+    pub fn add<R, O>(&self, other: &Grid<R>) -> Grid<O>
+    where
+        T: Add<R, Output = O>,
+        R: Clone,
+    {
+        self.ensure_dimensions_match(other);
+        let mut data: Vec<O> = Vec::with_capacity(self.data.len());
+        for (lhs, rhs) in self.data.iter().zip(other.data.iter()) {
+            data.push(lhs.clone().add(rhs.clone()));
+        }
+        Grid {
+            data,
+            width: self.width,
+            height: self.height,
+        }
+    }
+
+    /// adds each value in the grid with each value at the same
+    /// coordinate in the other grid
+    /// modifies the grid in place
+    ///
+    /// panics if dimensions don't match
+    pub fn add_inplace<R>(&mut self, other: &Grid<R>) -> &mut Self
+    where
+        T: Add<R, Output = T>,
+        R: Clone,
+    {
+        self.ensure_dimensions_match(other);
+        for (lhs, rhs) in self.data.iter_mut().zip(other.data.iter()) {
+            *lhs = lhs.clone().add(rhs.clone());
         }
         self
     }


### PR DESCRIPTION
Adds functions for doing math operations on grid values.
This is useful for using the library in dijkstra maps.  (https://www.roguebasin.com/index.php/Dijkstra_Maps_Visualized)

- adding/multiplying the values of grids with equal dimensions both in place and resulting in a new grid object
- multiplying all values in a grid with a scalar resulting in a new object
- clamping all values in a grid to a range

Let me know if you want me to change anything.